### PR TITLE
Changed manifesturl in about/manifest.xml

### DIFF
--- a/About/Manifest.xml
+++ b/About/Manifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Manifest>
   <version>1.1.3.0</version>
-  <manifestUri>https://rawgit.com/notfood/RimWorld-ResearchPal/master/About/Manifest.xml</manifestUri>
+  <manifestUri>https://raw.githubusercontent.com/notfood/RimWorld-ResearchPal/master/About/Manifest.xml</manifestUri>
   <downloadUri>https://github.com/notfood/RimWorld-ResearchPal/releases/latest</downloadUri>
 </Manifest>


### PR DESCRIPTION
it is now being served from https://raw.githubusercontent.com instead of dead rawgit
Actually searched some other mods and saw that serving from github itsels is pretty common